### PR TITLE
Bump logback-classic from 1.1.11 to 1.2.0 in /00_framework

### DIFF
--- a/00_framework/pom.xml
+++ b/00_framework/pom.xml
@@ -58,7 +58,7 @@
 		<slf4j_version>1.7.7</slf4j_version>
 		<jcl_version>1.1</jcl_version>
 		<log4j_version>1.2.16</log4j_version>
-		<logback_version>1.1.11</logback_version>
+		<logback_version>1.2.0</logback_version>
 		<logback-ext-spring_version>0.1.4</logback-ext-spring_version>
 		<!-- Test Libs -->
 		<junit_version>4.12</junit_version>


### PR DESCRIPTION
Bumps logback-classic from 1.1.11 to 1.2.0.

---
updated-dependencies:
- dependency-name: ch.qos.logback:logback-classic
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>